### PR TITLE
Changed VGG16 and VGG19 preprocessor functions to use official tf.ker…

### DIFF
--- a/src/deepspectrumlite/lib/data/data_pipeline.py
+++ b/src/deepspectrumlite/lib/data/data_pipeline.py
@@ -92,9 +92,9 @@ class DataPipeline:
 
         self.preprocessors = {
             "vgg16":
-                self.__preprocess_vgg,
+                tf.keras.applications.vgg16.preprocess_input,
             "vgg19":
-                self.__preprocess_vgg,
+                tf.keras.applications.vgg19.preprocess_input,
             "resnet50":
                 tf.keras.applications.resnet50.preprocess_input,
             "xception":
@@ -121,7 +121,10 @@ class DataPipeline:
                 tf.keras.applications.imagenet_utils.preprocess_input,
         }
 
-    def __preprocess_vgg(self, x):
+    def __preprocess_vgg(self, x, data_format=None):
+        """
+        Legacy function for VGG16 and VGG19 preprocessing without centering.
+        """
         x = x[:, :, :, ::-1]
         return x
 

--- a/src/deepspectrumlite/lib/data/embedded/preprocessor.py
+++ b/src/deepspectrumlite/lib/data/embedded/preprocessor.py
@@ -24,6 +24,7 @@ from deepspectrumlite import power_to_db, amplitude_to_db
 from deepspectrumlite.lib.data.plot import create_map_from_array, CividisColorMap, InfernoColorMap, MagmaColorMap, \
     PlasmaColorMap, ViridisColorMap
 import numpy as np
+import math
 
 
 # TODO refactor
@@ -55,9 +56,9 @@ class PreprocessAudio(tf.Module):
 
         self.preprocessors = {
             "vgg16":
-                self.__preprocess_vgg,
+                tf.keras.applications.vgg16.preprocess_input,
             "vgg19":
-                self.__preprocess_vgg,
+                tf.keras.applications.vgg19.preprocess_input,
             "resnet50":
                 tf.keras.applications.resnet50.preprocess_input,
             "xception":
@@ -84,12 +85,15 @@ class PreprocessAudio(tf.Module):
                 tf.keras.applications.imagenet_utils.preprocess_input,
         }
 
-    def __preprocess_vgg(self, x):
+    def __preprocess_vgg(self, x, data_format=None):
+        """
+        Legacy function for VGG16 and VGG19 preprocessing without centering.
+        """
         x = x[:, :, :, ::-1]
         return x
 
     @tf.function(input_signature=[tf.TensorSpec(shape=(1, 16000), dtype=tf.float32)])
-    def preprocess(self, audio_signal): # pragma: no cover
+    def preprocess(self, audio_signal):  # pragma: no cover
         decoded_audio = audio_signal * (0.7079 / tf.reduce_max(tf.abs(audio_signal)))
 
         frame_length = int(self.hparams['stft_window_size'] * self.hparams['sample_rate'])


### PR DESCRIPTION
…as.applications implementation instead of custom function which did identical mapping. Solves error thrown due to missing "data_format" argument. Added math import to preprocessor.py to resolve pi.