### PR TITLE
Include "output_activation" in sample hp-config.

### DIFF
--- a/src/deepspectrumlite/cli/config/hp_config.json
+++ b/src/deepspectrumlite/cli/config/hp_config.json
@@ -14,6 +14,7 @@
     "finetune_layer":   [0.7],
     "loss":             ["categorical_crossentropy"],
     "activation":       ["arelu"],
+    "output_activation": ["softmax"],
     "pre_epochs":       [40],
     "epochs":           [100],
     "batch_size":       [32],


### PR DESCRIPTION
If "output_activation" is not specified in the hparams config, the activation on the final layer will default to "softmax". Having it explicitly in the example should prevent some confusion, e.g., when running regression tasks.